### PR TITLE
Lookup fix

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
-Django==2.2
+Django==2.2.2
 elasticsearch_dsl==6.1.0
 pycountry==18.12.8
-requests==2.18.4
+requests==2.20.0
 requests-aws4auth==0.9
 mock==2.0.0
 base32_crockford==0.3.0

--- a/rorapi/management/commands/convertgrid.py
+++ b/rorapi/management/commands/convertgrid.py
@@ -1,5 +1,6 @@
 import base32_crockford
 import json
+import os.path
 import random
 import zipfile
 from rorapi.settings import ES, ES_VARS, ROR_API, GRID
@@ -66,7 +67,7 @@ class Command(BaseCommand):
             self.stdout.write('GRID dataset already converted')
             return
 
-        if not zipfile.is_zipfile(GRID['ROR_JSON_PATH']):
+        if not os.path.isfile(GRID['ROR_JSON_PATH']):
             with open(GRID['GRID_JSON_PATH'], 'r') as it:
                 grid_data = json.load(it)
 

--- a/rorapi/queries.py
+++ b/rorapi/queries.py
@@ -54,7 +54,7 @@ class ESQueryBuilder():
 def get_ror_id(string):
     """Extracts ROR id from a string and transforms it into canonical form"""
 
-    m = re.match(r'^(?:(?:http|https):\/\/)?(?:ror\.org\/)?(0\w{6}\d{2})$',
+    m = re.match(r'^(?:(?:(?:http|https):\/\/)?ror\.org\/)?(0\w{6}\d{2})$',
                  string)
     if m is not None:
         return ROR_API['ID_PREFIX'] + m.group(1)

--- a/rorapi/tests/tests_queries.py
+++ b/rorapi/tests/tests_queries.py
@@ -103,14 +103,12 @@ class GetRorIDTestCase(SimpleTestCase):
 
     def test_no_id(self):
         self.assertIsNone(get_ror_id('no id here'))
+        self.assertIsNone(get_ror_id('http://0w7hudk23'))
+        self.assertIsNone(get_ror_id('https://0w7hudk23'))
 
     def test_extract_id(self):
         self.assertEquals(get_ror_id('0w7hudk23'), 'https://ror.org/0w7hudk23')
         self.assertEquals(get_ror_id('ror.org/0w7hudk23'),
-                          'https://ror.org/0w7hudk23')
-        self.assertEquals(get_ror_id('http://0w7hudk23'),
-                          'https://ror.org/0w7hudk23')
-        self.assertEquals(get_ror_id('https://0w7hudk23'),
                           'https://ror.org/0w7hudk23')
         self.assertEquals(get_ror_id('http://ror.org/0w7hudk23'),
                           'https://ror.org/0w7hudk23')

--- a/rorapi/tests_integration/tests.py
+++ b/rorapi/tests_integration/tests.py
@@ -180,9 +180,13 @@ class APITestCase(SimpleTestCase):
 
     def test_retrieval(self):
         for test_org in requests.get(BASE_URL).json()['items']:
-            output = requests.get(BASE_URL + '/' + test_org['id']).json()
-
-            self.assertEquals(output, test_org)
+            for test_id in \
+                [test_org['id'],
+                 re.sub('https', 'http', test_org['id']),
+                 re.sub(r'https:\/\/', '', test_org['id']),
+                 re.sub(r'https:\/\/ror.org\/', '', test_org['id'])]:
+                output = requests.get(BASE_URL + '/' + test_id).json()
+                self.assertEquals(output, test_org)
 
     def test_error(self):
         output = requests.get(BASE_URL, {'query': 'query',

--- a/rorapi/tests_integration/tests_data_dump.py
+++ b/rorapi/tests_integration/tests_data_dump.py
@@ -1,0 +1,45 @@
+import json
+import os
+import re
+import random
+import requests
+import zipfile
+
+from django.test import SimpleTestCase
+from ..settings import GRID
+
+
+BASE_URL = '{}/organizations'.format(
+    os.environ.get('ROR_BASE_URL', 'http://localhost'))
+
+
+class DataDumpTestCase(SimpleTestCase):
+
+    def setUp(self):
+        with zipfile.ZipFile(GRID['ROR_ZIP_PATH'], 'r') as z:
+            with z.open('ror.json') as f:
+                data = f.read()
+                self.data_dump = json.loads(data.decode("utf-8"))
+
+    def test_data_dump(self):
+        # sanity check
+        self.assertTrue(len(self.data_dump) > 90000)
+        # schema check
+        for item in self.data_dump:
+            for l in ['external_ids', 'links', 'acronyms', 'types', 'name',
+                      'country', 'aliases', 'wikipedia_url', 'labels', 'id']:
+                self.assertTrue(l in item)
+            self.assertTrue('GRID' in item['external_ids'])
+            self.assertTrue('country_code' in item['country'])
+            self.assertTrue('country_name' in item['country'])
+            self.assertIsNotNone(re.match(r'https:\/\/ror\.org\/0\w{6}\d{2}',
+                                          item['id']))
+
+    def test_compare_data_dump_and_index(self):
+        data_index = requests.get(BASE_URL).json()
+        self.assertEquals(data_index['number_of_results'], len(self.data_dump))
+
+        sample = random.sample(self.data_dump, 100)
+        for item_dump in sample:
+            item_index = requests.get(BASE_URL + '/' + item_dump['id']).json()
+            self.assertEquals(item_index, item_dump)

--- a/rorapi/views.py
+++ b/rorapi/views.py
@@ -5,12 +5,12 @@ from django.views import View
 
 from .models import OrganizationSerializer, ListResultSerializer, \
     ErrorsSerializer
-from .queries import search_organizations, retrieve_organization
+from .queries import search_organizations, retrieve_organization, get_ror_id
 
 
 class OrganizationViewSet(viewsets.ViewSet):
 
-    lookup_value_regex = r'https:\/\/ror\.org\/0\w{6}\d{2}'
+    lookup_value_regex = r'((https?:\/\/)?ror\.org\/)?0\w{6}\d{2}'
 
     def list(self, request):
         params = request.GET.dict()
@@ -23,7 +23,8 @@ class OrganizationViewSet(viewsets.ViewSet):
         return Response(serializer.data)
 
     def retrieve(self, request, pk=None):
-        errors, organization = retrieve_organization(pk)
+        ror_id = get_ror_id(pk)
+        errors, organization = retrieve_organization(ror_id)
         if errors is not None:
             return Response(ErrorsSerializer(errors).data)
         serializer = OrganizationSerializer(organization)


### PR DESCRIPTION
- Fix the lookup. Any of the following can be now used:
  - organizations/https://ror.org/02bfwt286
  - organizations/http://ror.org/02bfwt286
  - organizations/ror.org/02bfwt286
  - organizations/02bfwt286
- Tests for the data dump file
- Upgrade libraries to get rid of potential security vulnerabilities reported by GitHub
- Check if ROR_JSON_PATH exists instead of checking if it as a ZIP file