### PR TITLE
support url-encoded ror identifier string

### DIFF
--- a/rorapi/queries.py
+++ b/rorapi/queries.py
@@ -6,6 +6,7 @@ from .settings import ES, ES_VARS, ROR_API
 from elasticsearch_dsl import Search
 from urllib.parse import unquote
 
+
 class ESQueryBuilder():
     """Elasticsearch query builder class"""
 

--- a/rorapi/queries.py
+++ b/rorapi/queries.py
@@ -4,7 +4,7 @@ from .models import Organization, ListResult, Errors
 from .settings import ES, ES_VARS, ROR_API
 
 from elasticsearch_dsl import Search
-
+from urllib.parse import unquote
 
 class ESQueryBuilder():
     """Elasticsearch query builder class"""
@@ -55,7 +55,7 @@ def get_ror_id(string):
     """Extracts ROR id from a string and transforms it into canonical form"""
 
     m = re.match(r'^(?:(?:(?:http|https):\/\/)?ror\.org\/)?(0\w{6}\d{2})$',
-                 string)
+                 unquote(string))
     if m is not None:
         return ROR_API['ID_PREFIX'] + m.group(1)
     return None

--- a/rorapi/tests/tests_queries.py
+++ b/rorapi/tests/tests_queries.py
@@ -102,6 +102,8 @@ class GetRorIDTestCase(SimpleTestCase):
                           'https://ror.org/0w7hudk23')
         self.assertEquals(get_ror_id('http://ror.org/0w7hudk23'),
                           'https://ror.org/0w7hudk23')
+        self.assertEquals(get_ror_id('http%3A%2F%2Fror.org%2F0w7hudk23'),
+                          'https://ror.org/0w7hudk23')
         self.assertEquals(get_ror_id('https://ror.org/0w7hudk23'),
                           'https://ror.org/0w7hudk23')
         self.assertEquals(get_ror_id('https%3A%2F%2Fror.org%2F0w7hudk23'),
@@ -176,9 +178,13 @@ class BuildSearchQueryTestCase(SimpleTestCase):
         self.assertEquals(query.to_dict(), expected)
         query = build_search_query({'query': 'http://ror.org/0w7hudk23'})
         self.assertEquals(query.to_dict(), expected)
+        query = build_search_query(
+            {'query': 'http%3A%2F%2Fror.org%2F0w7hudk23'})
+        self.assertEquals(query.to_dict(), expected)
         query = build_search_query({'query': 'https://ror.org/0w7hudk23'})
         self.assertEquals(query.to_dict(), expected)
-        query = build_search_query({'query': 'https%3A%2F%2Fror.org%2F0w7hudk23'})
+        query = build_search_query(
+            {'query': 'https%3A%2F%2Fror.org%2F0w7hudk23'})
         self.assertEquals(query.to_dict(), expected)
 
     def test_query_ui(self):

--- a/rorapi/tests/tests_queries.py
+++ b/rorapi/tests/tests_queries.py
@@ -110,9 +110,13 @@ class GetRorIDTestCase(SimpleTestCase):
         self.assertEquals(get_ror_id('0w7hudk23'), 'https://ror.org/0w7hudk23')
         self.assertEquals(get_ror_id('ror.org/0w7hudk23'),
                           'https://ror.org/0w7hudk23')
+        self.assertEquals(get_ror_id('ror.org%2F0w7hudk23'),
+                          'https://ror.org/0w7hudk23')
         self.assertEquals(get_ror_id('http://ror.org/0w7hudk23'),
                           'https://ror.org/0w7hudk23')
         self.assertEquals(get_ror_id('https://ror.org/0w7hudk23'),
+                          'https://ror.org/0w7hudk23')
+        self.assertEquals(get_ror_id('https%3A%2F%2Fror.org%2F0w7hudk23'),
                           'https://ror.org/0w7hudk23')
 
 

--- a/rorapi/tests/tests_queries.py
+++ b/rorapi/tests/tests_queries.py
@@ -172,9 +172,13 @@ class BuildSearchQueryTestCase(SimpleTestCase):
         self.assertEquals(query.to_dict(), expected)
         query = build_search_query({'query': 'ror.org/0w7hudk23'})
         self.assertEquals(query.to_dict(), expected)
+        query = build_search_query({'query': 'ror.org%2F0w7hudk23'})
+        self.assertEquals(query.to_dict(), expected)
         query = build_search_query({'query': 'http://ror.org/0w7hudk23'})
         self.assertEquals(query.to_dict(), expected)
         query = build_search_query({'query': 'https://ror.org/0w7hudk23'})
+        self.assertEquals(query.to_dict(), expected)
+        query = build_search_query({'query': 'https%3A%2F%2Fror.org%2F0w7hudk23'})
         self.assertEquals(query.to_dict(), expected)
 
     def test_query_ui(self):

--- a/rorapi/tests_integration/tests.py
+++ b/rorapi/tests_integration/tests.py
@@ -174,7 +174,8 @@ class APITestCase(SimpleTestCase):
                     [test_org['id'],
                      re.sub('https', 'http', test_org['id']),
                      re.sub(r'https:\/\/', '', test_org['id']),
-                     re.sub(r'https:\/\/ror.org\/', '', test_org['id'])]:
+                     re.sub(r'https:\/\/ror.org\/', '', test_org['id']),
+                     re.sub(r'https%3A%2F%2Fror.org%2F', '', test_org['id'])]:
                 output = requests.get(BASE_URL, {'query': test_id}).json()
                 self.verify_single_item(output, test_org)
 
@@ -184,7 +185,8 @@ class APITestCase(SimpleTestCase):
                 [test_org['id'],
                  re.sub('https', 'http', test_org['id']),
                  re.sub(r'https:\/\/', '', test_org['id']),
-                 re.sub(r'https:\/\/ror.org\/', '', test_org['id'])]:
+                 re.sub(r'https:\/\/ror.org\/', '', test_org['id']),
+                 re.sub(r'https%3A%2F%2Fror.org%2F', '', test_org['id'])]:
                 output = requests.get(BASE_URL + '/' + test_id).json()
                 self.assertEquals(output, test_org)
 

--- a/rorapi/tests_integration/tests.py
+++ b/rorapi/tests_integration/tests.py
@@ -171,11 +171,15 @@ class APITestCase(SimpleTestCase):
     def test_query_retrieval(self):
         for test_org in requests.get(BASE_URL).json()['items']:
             for test_id in \
-                    [test_org['id'],
-                     re.sub('https', 'http', test_org['id']),
-                     re.sub(r'https:\/\/', '', test_org['id']),
-                     re.sub(r'https:\/\/ror.org\/', '', test_org['id']),
-                     re.sub(r'https%3A%2F%2Fror.org%2F', '', test_org['id'])]:
+                [test_org['id'],
+                 re.sub('https', 'http', test_org['id']),
+                 re.sub(r'https:\/\/', '', test_org['id']),
+                 re.sub(r'https:\/\/ror.org\/', '', test_org['id']),
+                 re.sub(r'https:\/\/ror.org\/', r'ror.org%2F', test_org['id']),
+                 re.sub(r'https:\/\/ror.org\/', r'http%3A%2F%2Fror.org%2F',
+                        test_org['id']),
+                 re.sub(r'https:\/\/ror.org\/', r'https%3A%2F%2Fror.org%2F',
+                        test_org['id'])]:
                 output = requests.get(BASE_URL, {'query': test_id}).json()
                 self.verify_single_item(output, test_org)
 
@@ -186,7 +190,11 @@ class APITestCase(SimpleTestCase):
                  re.sub('https', 'http', test_org['id']),
                  re.sub(r'https:\/\/', '', test_org['id']),
                  re.sub(r'https:\/\/ror.org\/', '', test_org['id']),
-                 re.sub(r'https%3A%2F%2Fror.org%2F', '', test_org['id'])]:
+                 re.sub(r'https:\/\/ror.org\/', r'ror.org%2F', test_org['id']),
+                 re.sub(r'https:\/\/ror.org\/', r'http%3A%2F%2Fror.org%2F',
+                        test_org['id']),
+                 re.sub(r'https:\/\/ror.org\/', r'https%3A%2F%2Fror.org%2F',
+                        test_org['id'])]:
                 output = requests.get(BASE_URL + '/' + test_id).json()
                 self.assertEquals(output, test_org)
 

--- a/rorapi/views.py
+++ b/rorapi/views.py
@@ -10,7 +10,8 @@ from .queries import search_organizations, retrieve_organization, get_ror_id
 
 class OrganizationViewSet(viewsets.ViewSet):
 
-    lookup_value_regex = r'((https?:\/\/)?ror\.org\/)?0\w{6}\d{2}'
+    lookup_value_regex = \
+        r'((https?(:\/\/|%3A%2F%2F))?ror\.org(\/|%2F))?0\w{6}\d{2}'
 
     def list(self, request):
         params = request.GET.dict()


### PR DESCRIPTION
Support ROR ID in formats `ror.org%2F0w7hudk23` or `https%3A%2F%2Fror.org%2F0w7hudk23`.