### PR TITLE
remove escaping from string_query

### DIFF
--- a/rorapi/queries.py
+++ b/rorapi/queries.py
@@ -26,8 +26,6 @@ class ESQueryBuilder():
                                         fields=fields)
 
     def add_string_query(self, terms):
-        terms = re.sub(r'([\+\-=\&\|><!\(\)\{\}\[\]\^"\~\*\?:\\\/])',
-                       lambda m: '\\' + m.group(), terms)
         self.search = self.search.query('query_string', query=terms)
 
     def add_name_query(self, terms):

--- a/rorapi/tests/tests_queries.py
+++ b/rorapi/tests/tests_queries.py
@@ -44,18 +44,6 @@ class QueryBuilderTestCase(SimpleTestCase):
         self.assertEqual(qb.get_query().to_dict(),
                          {'query': {'query_string': {'query': 'query terms'}}})
 
-    def test_string_query_escaped(self):
-        qb = ESQueryBuilder()
-        qb.add_string_query(
-            r'query + - = && || > < ! ( ) { } [ ] ^ " ~ * ? : \ / to escape')
-
-        self.assertEqual(
-            qb.get_query().to_dict(),
-            {'query':
-             {'query_string':
-              {'query': r'query \+ \- \= \&\& \|\| \> \< \! \( \) \{ \} ' +
-                        r'\[ \] \^ \" \~ \* \? \: \\ \/ to escape'}}})
-
     def test_name_query(self):
         qb = ESQueryBuilder()
         qb.add_name_query('query terms')

--- a/rorapi/tests_functional/tests_matching.py
+++ b/rorapi/tests_functional/tests_matching.py
@@ -1,5 +1,6 @@
 import json
 import os
+import re
 import requests
 
 from django.test import SimpleTestCase
@@ -15,6 +16,8 @@ API_URL = os.environ.get('ROR_BASE_URL', 'http://localhost')
 class AffiliationMatchingTestCase(SimpleTestCase):
 
     def match(self, affiliation):
+        affiliation = re.sub(r'([\+\-=\&\|><!\(\)\{\}\[\]\^"\~\*\?:\\\/])',
+                             lambda m: '\\' + m.group(), affiliation)
         results = requests.get('{}/organizations'.format(API_URL),
                                {'query': affiliation}).json()
         if 'items' not in results:

--- a/rorapi/tests_functional/tests_search.py
+++ b/rorapi/tests_functional/tests_search.py
@@ -1,5 +1,6 @@
 import json
 import os
+import re
 import requests
 
 from django.test import SimpleTestCase
@@ -15,6 +16,8 @@ API_URL = os.environ.get('ROR_BASE_URL', 'http://localhost')
 class SearchTestCase(SimpleTestCase):
 
     def search(self, query):
+        query = re.sub(r'([\+\-=\&\|><!\(\)\{\}\[\]\^"\~\*\?:\\\/])',
+                       lambda m: '\\' + m.group(), query)
         results = requests.get('{}/organizations'.format(API_URL),
                                {'query': query}).json()
         if 'items' not in results:

--- a/rorapi/tests_integration/tests.py
+++ b/rorapi/tests_integration/tests.py
@@ -188,6 +188,12 @@ class APITestCase(SimpleTestCase):
                 output = requests.get(BASE_URL + '/' + test_id).json()
                 self.assertEquals(output, test_org)
 
+    def test_query_grid_retrieval(self):
+        for test_org in requests.get(BASE_URL).json()['items']:
+            grid = test_org['external_ids']['GRID']['preferred']
+            output = requests.get(BASE_URL, {'query': '"' + grid + '"'}).json()
+            self.verify_single_item(output, test_org)
+
     def test_error(self):
         output = requests.get(BASE_URL, {'query': 'query',
                                          'illegal': 'whatever',


### PR DESCRIPTION
Previously, the query was escaped in the code. Now it's up to the client. Fixes #47 