### PR TITLE
Specifying container name for ROR API web server

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,7 @@ services:
       interval: 10s
       timeout: 1s
   web:
+    container_name: rorapiweb
     env_file: .env
     environment:
       ELASTIC_HOST: elasticsearch


### PR DESCRIPTION
**The short version:** If Docker Compose assigns container names automatically, it assigns a name to the "web" container (`ror-api_web`) that Django rejects as an invalid hostname. This PR specifies a container name without underscores, which satisfies Django's criteria.

**The longer version:**
I'm not sure how niche of a concern this is, but the ROR API has been unbelievably helpful to me and I thought this might be of use to somebody. As currently configured, Docker Compose automatically generates container names for the containers spun up by this file. Normally this wouldn't matter. However, I was attempting to call the API container from _another container on the same network_. This can be a handy way around fiddling with DNS manually, since the container name can be used as the domain name. Unfortunately, the default name for the "web" container is `ror-api_web`, which (because of the underscores) is rejected by Django as an invalid hostname. So when my other container sends a GET to `http://ror-api_web/organizations/abcd`, the response is always a server error because the API gets confused about why its hostname doesn't follow RFC 1035.

Making the change in this PR makes the API available at`http://rorapiweb/organizations/abcd` instead, which solves this issue. Again, this issue would only pop up if you were trying to talk to the ROR API container from _another_ container, but that happened to be my use case, and I haven't been able to find anything else that depends on the default name.