### PR TITLE
Index names and ids as child documents

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,11 +46,6 @@ after_success:
       docker push $REPO:$TRAVIS_BRANCH;
       echo "Pushed to" $REPO:$TRAVIS_BRANCH;
       AUTO_DEPLOY=true;
-    elif [[ "$TRAVIS_BRANCH" == "feature/index_child_docs" && "$TRAVIS_PULL_REQUEST" == "false" ]]; then
-      docker build -f Dockerfile -t $REPO:$TRAVIS_BRANCH .;
-      docker push $REPO:$TRAVIS_BRANCH;
-      echo "Pushed to" $REPO:$TRAVIS_BRANCH;
-      AUTO_DEPLOY=true;
     else
       docker build -f Dockerfile -t $REPO:$TRAVIS_BRANCH .;
       docker push $REPO:$TRAVIS_BRANCH;

--- a/rorapi/es_utils.py
+++ b/rorapi/es_utils.py
@@ -7,6 +7,7 @@ class ESQueryBuilder():
     """Elasticsearch query builder class"""
     def __init__(self):
         self.search = Search(using=ES, index=ES_VARS['INDEX'])
+        self.search = self.search.params(search_type='dfs_query_then_fetch')
 
     def add_id_query(self, id):
         self.search = self.search.query('match',

--- a/rorapi/es_utils.py
+++ b/rorapi/es_utils.py
@@ -19,9 +19,12 @@ class ESQueryBuilder():
         self.search = self.search.query('match_all')
 
     def add_string_query(self, terms):
-        self.search = self.search.query('query_string',
-                                        query=terms,
-                                        fuzzy_max_expansions=1)
+        self.search = self.search.query('nested',
+                                        path='names_ids',
+                                        score_mode='max',
+                                        query=Q('query_string',
+                                                query=terms,
+                                                fuzzy_max_expansions=1))
 
     def add_phrase_query(self, fields, terms):
         self.search.query = Q(

--- a/rorapi/index_template.json
+++ b/rorapi/index_template.json
@@ -33,7 +33,10 @@
             }
           },
           "links": {
-            "type": "text"
+            "type": "keyword"
+          },
+          "wikipedia_url": {
+            "type": "keyword"
           },
           "aliases": {
             "type": "text",
@@ -61,21 +64,9 @@
               }
             }
           },
-
           "status": {
-            "type": "text",
-            "fields": { 
-              "keyword": { 
-                "type": "keyword" 
-              }, 
-              "norm": { 
-                "type": "text", 
-                "analyzer": "string_lowercase", 
-                "fielddata": true 
-              }
-            }
+            "type": "keyword"
           },
-
           "labels": {
             "properties": {
               "label": {
@@ -150,6 +141,19 @@
                 }
               }
             } 
+          },
+
+          "names_ids": {
+            "type": "nested",
+            "properties": {
+              "id": {
+                "type": "keyword"
+              },
+              "name": {
+                "type": "text",
+                "analyzer": "string_lowercase"
+              }
+            }
           }
         }
       }

--- a/rorapi/tests/tests_es_utils.py
+++ b/rorapi/tests/tests_es_utils.py
@@ -34,9 +34,15 @@ class QueryBuilderTestCase(SimpleTestCase):
         self.assertEqual(
             qb.get_query().to_dict(), {
                 'query': {
-                    'query_string': {
-                        'query': 'query terms',
-                        'fuzzy_max_expansions': 1
+                    'nested': {
+                        'path': 'names_ids',
+                        'score_mode': 'max',
+                        'query': {
+                            'query_string': {
+                                'query': 'query terms',
+                                'fuzzy_max_expansions': 1
+                            }
+                        }
                     }
                 }
             })

--- a/rorapi/tests/tests_queries.py
+++ b/rorapi/tests/tests_queries.py
@@ -128,9 +128,15 @@ class BuildSearchQueryTestCase(SimpleTestCase):
             query.to_dict(),
             dict(self.default_query,
                  query={
-                     'query_string': {
-                         'query': 'query terms',
-                         'fuzzy_max_expansions': 1
+                     'nested': {
+                         'path': 'names_ids',
+                         'score_mode': 'max',
+                         'query': {
+                             'query_string': {
+                                 'query': 'query terms',
+                                 'fuzzy_max_expansions': 1
+                             }
+                         }
                      }
                  }))
 
@@ -154,9 +160,15 @@ class BuildSearchQueryTestCase(SimpleTestCase):
                          'filter':
                          e,
                          'must': [{
-                             'query_string': {
-                                 'query': 'query terms',
-                                 'fuzzy_max_expansions': 1
+                             'nested': {
+                                 'path': 'names_ids',
+                                 'score_mode': 'max',
+                                 'query': {
+                                     'query_string': {
+                                         'query': 'query terms',
+                                         'fuzzy_max_expansions': 1
+                                     }
+                                 }
                              }
                          }]
                      }
@@ -174,9 +186,15 @@ class BuildSearchQueryTestCase(SimpleTestCase):
             query.to_dict(),
             dict(base,
                  query={
-                     'query_string': {
-                         'query': 'query terms',
-                         'fuzzy_max_expansions': 1
+                     'nested': {
+                         'path': 'names_ids',
+                         'score_mode': 'max',
+                         'query': {
+                             'query_string': {
+                                 'query': 'query terms',
+                                 'fuzzy_max_expansions': 1
+                             }
+                         }
                      }
                  }))
 


### PR DESCRIPTION
This change to the index makes all name variants and IDs indexed as separate child documents of the main org document. Searching is then done against those child documents. This improves search results significantly.