### PR TITLE
fix fuzzy search threshold

### DIFF
--- a/rorapi/tests_functional/tests_search.py
+++ b/rorapi/tests_functional/tests_search.py
@@ -88,7 +88,7 @@ class QueryFuzzySearchTestCase(SearchTestCase):
         ]
         self.rank_max = RANK_MAX_QUERY_FUZZY
         self.r1_min = R1_MIN_QUERY_FUZZY
-        self.r5_min = R5_MIN_QUERY
+        self.r5_min = R5_MIN_QUERY_FUZZY
 
     def test_search_query(self):
         self.validate('query (fuzzy)')


### PR DESCRIPTION
Fuzzy search threshold is incorrect, which combined with a small decrease in the test results caused the test to fail in current master branch. This PR fixes the wrong threshold and will fix the failing test in master branch as well.