### PR TITLE
Fix container builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM phusion/passenger-full:0.9.30
+FROM phusion/passenger-full:1.0.12
 MAINTAINER Martin Fenner "mfenner@datacite.org"
 
 # Set correct environment variables
@@ -44,7 +44,7 @@ COPY vendor/docker/10_ssh.sh /etc/my_init.d/10_ssh.sh
 WORKDIR /home/app/webapp
 
 # point /usr/bin/python to Python3
-RUN ln -s -f /usr/bin/python3.5 /usr/bin/python
+RUN ln -s -f /usr/bin/python3 /usr/bin/python
 
 # install Python packages
 RUN pip3 install --no-cache-dir --upgrade pip

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,4 +15,4 @@ django-cors-headers==3.1.0
 unidecode==1.1.1
 fuzzywuzzy==0.17.0
 python-Levenshtein==0.12.0
-statsmodels==0.10.1
+statsmodels==0.10.2


### PR DESCRIPTION
tl:dr; need newer python, we get this with newer passenger, and we need a newer version of a pip module as well.

Long story: The update pip script is using a new string format, which is only supported in python 3.6 or greater (https://github.com/pypa/pip/issues/9500#issuecomment-766291496). 

This caused me to jump versions of passenger to get python 3.8 without hassle.
Additionally installation of requirements still seemed to break, notably statsmodels, so I bumped that to latest too.

We may explore other fixes, putting this up as a known path forward for now.