### PR TITLE
Affiliation search improvements

### DIFF
--- a/rorapi/countries.txt
+++ b/rorapi/countries.txt
@@ -1,6 +1,7 @@
 ad andorra
 ae al imarat al arabiyah al muttahidah
 ae arab emirates
+ae uae
 ae united arab emirates
 af afghanestan
 af afghanistan
@@ -436,6 +437,7 @@ ua ukr
 ua ukraine
 ua ukrayina
 ug uganda
+uk gb
 uk gbr
 uk great britain
 uk northern ireland

--- a/rorapi/matching.py
+++ b/rorapi/matching.py
@@ -1,3 +1,4 @@
+import geonamescache
 import os
 import re
 import unidecode
@@ -10,22 +11,44 @@ from functools import lru_cache
 from fuzzywuzzy import fuzz
 from itertools import groupby
 
-MIN_MATCHING_SCORE = 0.9
+MIN_CHOSEN_SCORE = 0.9
+MIN_MATCHING_SCORE = 0.5
 
 MATCHING_TYPE_PHRASE = 'PHRASE'
 MATCHING_TYPE_COMMON = 'COMMON TERMS'
 MATCHING_TYPE_FUZZY = 'FUZZY'
 MATCHING_TYPE_HEURISTICS = 'HEURISTICS'
 MATCHING_TYPE_ACRONYM = 'ACRONYM'
+MATCHING_TYPE_EXACT = 'EXACT'
+
+SPECIAL_CHARS_REGEX = '[\+\-\=\|\>\<\!\(\)\\\{\}\[\]\^\"\~\*\?\:\/\.\,\;]'
+DO_NOT_MATCH = ['university hospital']
 
 #####################################################################
 # Country extraction                                                #
 #####################################################################
 
+@lru_cache(maxsize=None)
+def load_geonames_countries():
+    '''Load countries from geonames'''
+    gc = geonamescache.GeonamesCache()
+    gc_countries = gc.get_countries()
+    return gc_countries
+
+GEONAMES_COUNTRIES = load_geonames_countries()
+
+@lru_cache(maxsize=None)
+def load_geonames_cities():
+    '''Load countries with population > 15000 from geonames'''
+    gc = geonamescache.GeonamesCache()
+    gc_cities = gc.get_cities()
+    return gc_cities
+
+GEONAMES_CITIES = load_geonames_cities()
 
 @lru_cache(maxsize=None)
 def load_countries():
-    '''Load code-name map from the file'''
+    '''Load custom country code map from countries.txt'''
 
     countries = []
     with open(os.path.join(os.path.split(__file__)[0],
@@ -34,9 +57,7 @@ def load_countries():
         countries = [(line[0], ' '.join(line[1:])) for line in lines]
     return countries
 
-
 COUNTRIES = load_countries()
-
 
 def to_region(c):
     '''Map country code to "region" string.
@@ -75,18 +96,15 @@ def get_country_codes(string):
             codes.append(code.upper())
     return list(set(codes))
 
-
 def get_countries(string):
     '''Extract country codes the the string and map to regions.'''
 
     codes = get_country_codes(string)
     return [to_region(c) for c in codes]
 
-
 #####################################################################
 # Similarity                                                        #
 #####################################################################
-
 
 def normalize(s):
     '''Normalize string for matching.'''
@@ -122,10 +140,7 @@ def get_similarity(aff_sub, cand_name):
              if s in aff_sub]) > 1:
         comparfun = fuzz.partial_ratio
     cand_name = re.sub(r'\(.*\)', '', cand_name).strip()
-    if min(len(aff_sub), len(cand_name)) < 12:
-        return 1 if aff_sub == cand_name else 0
     return comparfun(aff_sub, cand_name) / 100
-
 
 def get_score(candidate, aff_sub, countries):
     '''Calculate the similarity between the affiliation substring
@@ -142,7 +157,6 @@ def get_score(candidate, aff_sub, countries):
         scores.append(1) if countries else scores.append(0.9)
     return max(scores)
 
-
 #####################################################################
 # Matching                                                          #
 #####################################################################
@@ -152,10 +166,8 @@ MatchedOrganization = namedtuple(
     ['chosen', 'substring', 'matching_type', 'score', 'organization'])
 MatchedOrganization.__new__.__defaults__ = (False, None, None, 0, None)
 
-
 def match_by_query(text, matching_type, query, countries):
     '''Match affiliation text using specific ES query.'''
-
     candidates = query.execute()
     scores = [(candidate, get_score(candidate, text, countries))
               for candidate in candidates]
@@ -176,7 +188,6 @@ def match_by_query(text, matching_type, query, countries):
     ]
     return chosen, all_matched
 
-
 def match_by_type(text, matching_type, countries):
     '''Match affiliation text using specific matching mode/type.'''
 
@@ -192,11 +203,19 @@ def match_by_type(text, matching_type, countries):
             substrings.append(h2.group())
             substrings.append('University of ' + h2.group(1))
     elif matching_type == MATCHING_TYPE_ACRONYM:
-        substrings = re.findall('[A-Z]{3,}', text)
+        iso3_substrings = []
+        all_substrings = re.findall('[A-Z]{3,}', text)
+        for substring in all_substrings:
+            for country in GEONAMES_COUNTRIES.values():
+                if substring.lower() == country['iso3'].lower():
+                    iso3_substrings.append(substring)
+        substrings = [x for x in all_substrings if x not in iso3_substrings]
+
     else:
         substrings.append(text)
 
     queries = [ESQueryBuilder() for _ in substrings]
+
     for s, q in zip(substrings, queries):
         if matching_type == MATCHING_TYPE_PHRASE:
             q.add_phrase_query(fields, normalize(text))
@@ -209,7 +228,6 @@ def match_by_type(text, matching_type, countries):
         elif matching_type == MATCHING_TYPE_HEURISTICS:
             q.add_common_query(fields, normalize(text))
     queries = [q.get_query() for q in queries]
-
     matched = [
         match_by_query(t, matching_type, q, countries)
         for t, q in zip(substrings, queries)
@@ -220,51 +238,20 @@ def match_by_type(text, matching_type, countries):
     all_matched = [m for sub in matched for m in sub[1]]
     max_score = max([m[0].score for m in matched])
     chosen = [m[0] for m in matched if m[0].score == max_score][0]
-    return chosen, all_matched
 
+    return chosen, all_matched
 
 class MatchingNode:
     '''Matching node class. Represents a substring of the original affiliation
     that potentially could be matched to an organization.'''
-    def __init__(self, text, children=[]):
+    def __init__(self, text):
         self.text = text
-        self.children = children
         self.matched = None
         self.all_matched = []
 
-    def get_children_max_score(self):
-        score = 0
-        for child in self.children:
-            if child.matched is not None and child.matched.score > score:
-                score = child.matched.score
-            child_tree_score = child.get_children_max_score()
-            if child_tree_score > score:
-                score = child_tree_score
-        return score
-
-    def remove_descendants_links(self):
-        for child in self.children:
-            child.matched = None
-            child.remove_descendants_links()
-
-    def prune_links(self):
-        if self.matched is None:
-            return
-        children_max_score = self.get_children_max_score()
-        if children_max_score >= self.matched.score:
-            self.matched = None
-        else:
-            self.remove_descendants_links()
-
     def get_matching_types(self):
-        if self.children:
-            return [
-                MATCHING_TYPE_PHRASE, MATCHING_TYPE_COMMON, MATCHING_TYPE_FUZZY
-            ]
-        else:
-            return [
-                MATCHING_TYPE_PHRASE, MATCHING_TYPE_COMMON,
-                MATCHING_TYPE_FUZZY, MATCHING_TYPE_HEURISTICS
+        return [
+                MATCHING_TYPE_PHRASE, MATCHING_TYPE_COMMON, MATCHING_TYPE_FUZZY, MATCHING_TYPE_HEURISTICS
             ]
 
     def match(self, countries, min_score):
@@ -278,6 +265,33 @@ class MatchingNode:
                     and self.matched.score < min_score:
                 self.matched = chosen
 
+def clean_search_string(search_string):
+    # strip special chars
+    search_string_cleaned = re.sub(SPECIAL_CHARS_REGEX, ' ', search_string)
+    # replace multiple spaces with 1 space
+    search_string_cleaned = re.sub(' +', ' ', search_string_cleaned)
+    search_string_cleaned = search_string_cleaned.strip()
+    # strip postal codes
+    search_string_cleaned = re.sub('\d{5}', '', search_string_cleaned)
+    return search_string_cleaned
+
+def check_do_not_match(search_string):
+    do_not_match = False
+    if search_string.lower() in DO_NOT_MATCH:
+        do_not_match = True
+        return do_not_match
+    else:
+        for country in GEONAMES_COUNTRIES.values():
+            if search_string.lower() == country['name'].lower() \
+                or search_string.lower() == country['iso'].lower() \
+                or search_string.lower() == country['iso3'].lower():
+                do_not_match = True
+                break
+        for city in GEONAMES_CITIES.values():
+            if search_string.lower() == city['name'].lower():
+                do_not_match = True
+                break
+    return do_not_match
 
 class MatchingGraph:
     '''A matching graph represents the entire input affiliation. The nodes
@@ -289,46 +303,26 @@ class MatchingGraph:
         self.nodes = []
         self.affiliation = affiliation
         affiliation = re.sub('&amp;', '&', affiliation)
-        prev = []
+        affiliation_cleaned = clean_search_string(affiliation)
+        n = MatchingNode(affiliation_cleaned)
+        self.nodes.append(n)
         for part in [s.strip() for s in re.split('[,;:]', affiliation)]:
-            part_norm = re.sub(' and ', ' & ', part)
-            if '&' in part_norm:
-                part1 = re.sub('&.*', '', part_norm).strip()
-                part2 = re.sub('.*&', '', part_norm).strip()
-                n1 = MatchingNode(part1)
-                n2 = MatchingNode(part2)
-                nn = MatchingNode(part, [n1, n2])
-                self.nodes.append(n1)
-                self.nodes.append(n2)
-                self.nodes.append(nn)
-                for p in prev:
-                    self.nodes.append(
-                        MatchingNode(p.text + ' ' + part1, [p, n1]))
-                    self.nodes.append(
-                        MatchingNode(p.text + ' ' + part, [p, nn]))
-                prev = [n2, nn]
-            else:
-                n = MatchingNode(part)
+            part_cleaned = clean_search_string(part)
+            do_not_match = check_do_not_match(part_cleaned)
+            # do not perform search if substring exactly matches a country name or ISO code
+            if do_not_match == False:
+                n = MatchingNode(part_cleaned)
                 self.nodes.append(n)
-                for p in prev:
-                    self.nodes.append(MatchingNode(p.text + ' ' + part,
-                                                   [p, n]))
-                prev = [n]
 
     def remove_low_scores(self, min_score):
         for node in self.nodes:
             if node.matched is not None and node.matched.score < min_score:
                 node.matched = None
 
-    def prune_links(self):
-        for node in self.nodes:
-            node.prune_links()
-
     def match(self, countries, min_score):
         for node in self.nodes:
             node.match(countries, min_score)
         self.remove_low_scores(min_score)
-        self.prune_links()
         chosen = []
         all_matched = []
         for node in self.nodes:
@@ -341,13 +335,22 @@ class MatchingGraph:
                                                     MATCHING_TYPE_ACRONYM,
                                                     countries)
         all_matched.extend(acr_all_matched)
-        if not chosen and acr_chosen.score >= min_score:
-            chosen.append(acr_chosen)
         return chosen, all_matched
 
+def get_chosen_larger_substr(chosen):
+    perfect_scores = [c for c in chosen if c.score == 1.0]
+    if len(perfect_scores) == len(chosen):
+        return([])
+    else:
+        return(chosen)
 
 def get_output(chosen, all_matched):
+    # don't allow multiple results with chosen=True
+    if isinstance(chosen, list) and len(chosen) > 1:
+        chosen = []
+
     type_map = {
+        MATCHING_TYPE_EXACT: 5,
         MATCHING_TYPE_PHRASE: 4,
         MATCHING_TYPE_COMMON: 3,
         MATCHING_TYPE_FUZZY: 2,
@@ -355,7 +358,7 @@ def get_output(chosen, all_matched):
         MATCHING_TYPE_ACRONYM: 0
     }
     output = []
-    all_matched = [m for m in all_matched if m.score > 0]
+    all_matched = [m for m in all_matched if m.score > MIN_MATCHING_SCORE]
     all_matched = sorted(all_matched, key=lambda x: x.organization.id)
     all_matched = groupby(all_matched, lambda x: x.organization.id)
     all_matched_list = []
@@ -372,25 +375,41 @@ def get_output(chosen, all_matched):
                                            matching_type=c.matching_type,
                                            organization=c.organization)
                 break
+            if c.score == 1.0 and \
+                    type_map[best.matching_type] == type_map[MATCHING_TYPE_EXACT] and \
+                    type_map[c.matching_type] == type_map[MATCHING_TYPE_EXACT]:
+                best = MatchedOrganization(substring=c.substring,
+                                           score=c.score,
+                                           chosen=True,
+                                           matching_type=c.matching_type,
+                                           organization=c.organization)
+                break
             if best.score < c.score:
                 best = c
             if best.score == c.score and \
                     type_map[best.matching_type] < type_map[c.matching_type]:
                 best = c
-            if best.score == c.score and \
-                    type_map[best.matching_type] == type_map[c.matching_type] \
-                    and len(best.substring) > len(c.substring):
+            if (best.score == c.score) and \
+                    type_map[best.matching_type] == type_map[c.matching_type] and \
+                    len(best.substring) >= len(c.substring):
                 best = c
         output.append(best)
     return sorted(output, key=lambda x: x.score, reverse=True)[:100]
 
+def check_exact_match(affiliation, countries):
+    qb = ESQueryBuilder()
+    qb.add_string_query('"' + affiliation + '"')
+    return match_by_query(affiliation, MATCHING_TYPE_EXACT, qb.get_query(), countries)
 
 def match_affiliation(affiliation):
     countries = get_countries(affiliation)
-    graph = MatchingGraph(affiliation)
-    chosen, all_matched = graph.match(countries, MIN_MATCHING_SCORE)
-    return get_output(chosen, all_matched)
-
+    exact_chosen, exact_all_matched = check_exact_match(affiliation, countries)
+    if exact_chosen.score == 1.0:
+        return get_output(exact_chosen, exact_all_matched)
+    else:
+        graph = MatchingGraph(affiliation)
+        chosen, all_matched = graph.match(countries, MIN_CHOSEN_SCORE)
+        return get_output(chosen, all_matched)
 
 def match_organizations(params):
     if 'affiliation' in params:

--- a/rorapi/matching.py
+++ b/rorapi/matching.py
@@ -21,8 +21,11 @@ MATCHING_TYPE_HEURISTICS = 'HEURISTICS'
 MATCHING_TYPE_ACRONYM = 'ACRONYM'
 MATCHING_TYPE_EXACT = 'EXACT'
 
+NODE_MATCHING_TYPES = (MATCHING_TYPE_PHRASE, MATCHING_TYPE_COMMON, \
+    MATCHING_TYPE_FUZZY, MATCHING_TYPE_HEURISTICS)
+
 SPECIAL_CHARS_REGEX = '[\+\-\=\|\>\<\!\(\)\\\{\}\[\]\^\"\~\*\?\:\/\.\,\;]'
-DO_NOT_MATCH = ['university hospital']
+DO_NOT_MATCH = ('university hospital')
 
 #####################################################################
 # Country extraction                                                #
@@ -249,13 +252,8 @@ class MatchingNode:
         self.matched = None
         self.all_matched = []
 
-    def get_matching_types(self):
-        return [
-                MATCHING_TYPE_PHRASE, MATCHING_TYPE_COMMON, MATCHING_TYPE_FUZZY, MATCHING_TYPE_HEURISTICS
-            ]
-
     def match(self, countries, min_score):
-        for matching_type in self.get_matching_types():
+        for matching_type in NODE_MATCHING_TYPES:
             chosen, all_matched = match_by_type(self.text, matching_type,
                                                 countries)
             self.all_matched.extend(all_matched)
@@ -337,18 +335,10 @@ class MatchingGraph:
         all_matched.extend(acr_all_matched)
         return chosen, all_matched
 
-def get_chosen_larger_substr(chosen):
-    perfect_scores = [c for c in chosen if c.score == 1.0]
-    if len(perfect_scores) == len(chosen):
-        return([])
-    else:
-        return(chosen)
-
 def get_output(chosen, all_matched):
     # don't allow multiple results with chosen=True
     if isinstance(chosen, list) and len(chosen) > 1:
         chosen = []
-
     type_map = {
         MATCHING_TYPE_EXACT: 5,
         MATCHING_TYPE_PHRASE: 4,

--- a/rorapi/tests/tests_matching.py
+++ b/rorapi/tests/tests_matching.py
@@ -1,17 +1,29 @@
 from django.test import SimpleTestCase
 
-from ..matching import load_countries, to_region, get_country_codes, \
+from ..matching import load_geonames_countries, load_geonames_cities, load_countries, to_region, get_country_codes, \
     get_countries, normalize, MatchedOrganization, get_similarity, get_score, \
-    MatchingNode, MatchingGraph, get_output, MATCHING_TYPE_PHRASE, \
-    MATCHING_TYPE_COMMON, MATCHING_TYPE_FUZZY
+    MatchingNode, clean_search_string, check_do_not_match, MatchingGraph, get_output, \
+    check_exact_match, MATCHING_TYPE_PHRASE, MATCHING_TYPE_COMMON, MATCHING_TYPE_FUZZY
 from .utils import AttrDict
 
 
 class CountriesTestCase(SimpleTestCase):
+    def test_load_geonames_countries(self):
+        countries = load_geonames_countries()
+
+        self.assertTrue('AZ' in countries)
+        self.assertTrue('FM' in countries)
+        self.assertTrue('ZM' in countries)
+
+    def test_load_geonames_cities(self):
+        cities = load_geonames_cities()
+
+        self.assertTrue('3031582' in cities)
+
     def test_load_countries(self):
         countries = load_countries()
 
-        self.assertEqual(len(countries), 588)
+        self.assertEqual(len(countries), 590)
         self.assertTrue(('az', 'azarbaycan respublikasi') in countries)
         self.assertTrue(('fm', 'federated states of micronesia') in countries)
         self.assertTrue(('zm', 'zambia') in countries)
@@ -183,8 +195,6 @@ class SimilarityTestCase(SimpleTestCase):
         self.assertEqual(
             get_similarity('excellençë univ', 'University of Excellence'),
             0.93)
-        self.assertEqual(get_similarity('excellençë', 'Excellence'), 1)
-        self.assertEqual(get_similarity('excellençë', 'Excellenc'), 0)
         self.assertEqual(
             get_similarity('University of Exçellence',
                            'University of Excellence (Gallifrey)'), 1)
@@ -347,224 +357,99 @@ class TestMatchingNode(SimpleTestCase):
     def test_init(self):
         empty = MatchingNode('text')
         self.assertEqual(empty.text, 'text')
-        self.assertEqual(empty.children, [])
         self.assertTrue(empty.matched is None)
-
-        node = MatchingNode('text', ['ch1', 'ch2'])
-        node.matched = 'obj'
-        self.assertEqual(node.text, 'text')
-        self.assertEqual(node.children, ['ch1', 'ch2'])
-        self.assertEqual(node.matched, 'obj')
-
-    def test_get_children_max_score(self):
-        empty = MatchingNode('text')
-        self.assertEqual(empty.get_children_max_score(), 0)
-
-        l1 = MatchingNode('l1')
-        l1.matched = MatchedOrganization(substring='s1',
-                                         score=60,
-                                         matching_type='q',
-                                         organization='obj')
-        l2 = MatchingNode('l2')
-        l2.matched = MatchedOrganization(substring='s2',
-                                         score=99,
-                                         matching_type='q',
-                                         organization='obj')
-        l3 = MatchingNode('l3')
-        l3.matched = MatchedOrganization(substring='s3',
-                                         score=42,
-                                         matching_type='q',
-                                         organization='obj')
-
-        node1 = MatchingNode('text', [l1])
-        node1.matched = MatchedOrganization(substring='s2',
-                                            score=99,
-                                            matching_type='q',
-                                            organization='obj')
-        self.assertEqual(node1.get_children_max_score(), 60)
-
-        node2 = MatchingNode('text', [l1, l2])
-        node2.matched = MatchedOrganization(substring='s3',
-                                            score=42,
-                                            matching_type='q',
-                                            organization='obj')
-        self.assertEqual(node2.get_children_max_score(), 99)
-
-        node3 = MatchingNode('text', [node2, l3])
-        self.assertEqual(node3.get_children_max_score(), 99)
-
-    def test_remove_descendants_links(self):
-        l1 = MatchingNode('l1')
-        l1.matched = 'm1'
-        l1.remove_descendants_links()
-        self.assertEqual(l1.matched, 'm1')
-
-        l1 = MatchingNode('l1')
-        l1.matched = 'm1'
-        l2 = MatchingNode('l2')
-        l2.matched = 'm2'
-        node1 = MatchingNode('text', [l1, l2])
-        node1.matched = 'm12'
-        node1.remove_descendants_links()
-        self.assertTrue(l1.matched is None)
-        self.assertTrue(l2.matched is None)
-        self.assertEqual(node1.matched, 'm12')
-
-        l1 = MatchingNode('l1')
-        l1.matched = 'm1'
-        l2 = MatchingNode('l2')
-        l2.matched = 'm2'
-        l3 = MatchingNode('l3')
-        l3.matched = 'm3'
-        node1 = MatchingNode('text', [l1, l2])
-        node1.matched = 'm12'
-        node2 = MatchingNode('text', [node1, l3])
-        node2.matched = 'm123'
-        node2.remove_descendants_links()
-        self.assertTrue(l1.matched is None)
-        self.assertTrue(l2.matched is None)
-        self.assertTrue(l3.matched is None)
-        self.assertTrue(node1.matched is None)
-        self.assertEqual(node2.matched, 'm123')
-
-    def test_prune_links(self):
-        l1 = MatchingNode('l1')
-        l1.matched = MatchedOrganization(substring='s1',
-                                         score=60,
-                                         matching_type='q',
-                                         organization='obj')
-        l1.prune_links()
-        self.assertTrue(l1.matched is not None)
-
-        l1 = MatchingNode('l1')
-        l1.matched = MatchedOrganization(substring='s1',
-                                         score=60,
-                                         matching_type='q',
-                                         organization='obj')
-        l2 = MatchingNode('l2')
-        l2.matched = MatchedOrganization(substring='s2',
-                                         score=99,
-                                         matching_type='q',
-                                         organization='obj')
-        l3 = MatchingNode('l3')
-        l3.matched = MatchedOrganization(substring='s3',
-                                         score=42,
-                                         matching_type='q',
-                                         organization='obj')
-        node1 = MatchingNode('text', [l1, l2])
-        node1.matched = MatchedOrganization(substring='s2',
-                                            score=99,
-                                            matching_type='q',
-                                            organization='obj')
-        node2 = MatchingNode('text', [node1, l3])
-        node2.matched = MatchedOrganization(substring='s3',
-                                            score=52,
-                                            matching_type='q',
-                                            organization='obj')
-
-        node2.prune_links()
-        self.assertTrue(l1.matched is not None)
-        self.assertTrue(l2.matched is not None)
-        self.assertTrue(l3.matched is not None)
-        self.assertTrue(node1.matched is not None)
-        self.assertTrue(node2.matched is None)
-
-        node3 = MatchingNode('text', [node1, l3])
-        node3.matched = MatchedOrganization(substring='s3',
-                                            score=100,
-                                            matching_type='q',
-                                            organization='obj')
-        node3.prune_links()
-        self.assertTrue(l1.matched is None)
-        self.assertTrue(l2.matched is None)
-        self.assertTrue(l3.matched is None)
-        self.assertTrue(node1.matched is None)
-        self.assertTrue(node3.matched is not None)
 
     def test_get_matching_types(self):
         empty = MatchingNode('text')
         self.assertEqual(len(empty.get_matching_types()), 4)
 
-        node = MatchingNode('text', ['ch1', 'ch2'])
-        self.assertEqual(len(node.get_matching_types()), 3)
+    def test_get_matching_types(self):
+        empty = MatchingNode('text')
+        self.assertEqual(len(empty.get_matching_types()), 4)
 
+
+class TestCleanSearchString(SimpleTestCase):
+    def test_init(self):
+        self.assertEqual(clean_search_string('university of excellence'),
+                         'university of excellence')
+        self.assertEqual(clean_search_string('ünivërsity óf éxcellençe'),
+                         'ünivërsity óf éxcellençe')
+        self.assertEqual(clean_search_string('University  of    ExceLLence'),
+                         'University of ExceLLence')
+        self.assertEqual(clean_search_string('The University of Excellence'),
+                         'The University of Excellence')
+        self.assertEqual(clean_search_string('University of Excellence & Brilliance'),
+                         'University of Excellence & Brilliance')
+        self.assertEqual(clean_search_string('U.S. University of Excellence'),
+                         'U S University of Excellence')
+        self.assertEqual(clean_search_string('University of Tech. & Excellence'),
+                         'University of Tech & Excellence')
+        self.assertEqual(clean_search_string('University of Tech, Excellence'),
+                         'University of Tech Excellence')
+        self.assertEqual(clean_search_string('University of Tech/Excellence'),
+                         'University of Tech Excellence')
+        self.assertEqual(clean_search_string('University of Tech: Excellence'),
+                         'University of Tech Excellence')
+        self.assertEqual(clean_search_string('University of Tech; Excellence'),
+                         'University of Tech Excellence')
+        self.assertEqual(clean_search_string('University of Tech Excellence;'),
+                         'University of Tech Excellence')
+
+class TestCheckDoNotMatch(SimpleTestCase):
+    def test_init(self):
+        self.assertTrue(check_do_not_match('university hospital')),
+        self.assertTrue(check_do_not_match('MX')),
+        self.assertTrue(check_do_not_match('Mexico')),
+        self.assertTrue(check_do_not_match('MEX')),
+        self.assertTrue(check_do_not_match('Bordeaux')),
+        self.assertFalse(check_do_not_match('university of excellence'))
 
 class TestMatchingGraph(SimpleTestCase):
     def test_init(self):
         graph = MatchingGraph('University of Excellence')
-        self.assertEqual(len(graph.nodes), 1)
+        self.assertEqual(len(graph.nodes), 2)
         self.assertEqual(graph.nodes[0].text, 'University of Excellence')
+        self.assertEqual(graph.nodes[1].text, 'University of Excellence')
 
         graph = \
             MatchingGraph('University of Excellence and Creativity Institute')
-        self.assertEqual(len(graph.nodes), 3)
-        self.assertEqual(graph.nodes[0].text, 'University of Excellence')
-        self.assertEqual(graph.nodes[1].text, 'Creativity Institute')
-        self.assertEqual(graph.nodes[2].text,
-                         'University of Excellence and Creativity Institute')
+        self.assertEqual(len(graph.nodes), 2)
+        self.assertEqual(graph.nodes[0].text, 'University of Excellence and Creativity Institute')
+        self.assertEqual(graph.nodes[1].text, 'University of Excellence and Creativity Institute')
 
         graph = \
             MatchingGraph('University of Excellence & Creativity Institute')
-        self.assertEqual(len(graph.nodes), 3)
-        self.assertEqual(graph.nodes[0].text, 'University of Excellence')
-        self.assertEqual(graph.nodes[1].text, 'Creativity Institute')
-        self.assertEqual(graph.nodes[2].text,
+        self.assertEqual(len(graph.nodes), 2)
+        self.assertEqual(graph.nodes[0].text,
+                         'University of Excellence & Creativity Institute')
+        self.assertEqual(graph.nodes[1].text,
                          'University of Excellence & Creativity Institute')
 
         graph = MatchingGraph(
             'University of Excellence &amp; Creativity Institute')
-        self.assertEqual(len(graph.nodes), 3)
-        self.assertEqual(graph.nodes[0].text, 'University of Excellence')
-        self.assertEqual(graph.nodes[1].text, 'Creativity Institute')
-        self.assertEqual(graph.nodes[2].text,
+        self.assertEqual(len(graph.nodes), 2)
+        self.assertEqual(graph.nodes[0].text,
+                         'University of Excellence & Creativity Institute')
+        self.assertEqual(graph.nodes[1].text,
                          'University of Excellence & Creativity Institute')
 
         graph = MatchingGraph('University of Excellence, Creativity Institute')
         self.assertEqual(len(graph.nodes), 3)
-        self.assertEqual(graph.nodes[0].text, 'University of Excellence')
-        self.assertEqual(graph.nodes[1].text, 'Creativity Institute')
-        self.assertEqual(graph.nodes[2].text,
+        self.assertEqual(graph.nodes[0].text,
                          'University of Excellence Creativity Institute')
+        self.assertEqual(graph.nodes[1].text, 'University of Excellence')
+        self.assertEqual(graph.nodes[2].text, 'Creativity Institute')
+
 
         graph = MatchingGraph('School of Brilliance, University of ' +
                               'Excellence and Perseverance; 21-100 ' +
                               'Gallifrey: Outerspace')
-        self.assertEqual(len(graph.nodes), 11)
-        self.assertEqual(graph.nodes[0].text, 'School of Brilliance')
-        self.assertEqual(graph.nodes[1].text, 'University of Excellence')
-        self.assertEqual(graph.nodes[2].text, 'Perseverance')
-        self.assertEqual(graph.nodes[3].text,
-                         'University of Excellence and Perseverance')
-        self.assertEqual(len(graph.nodes[3].children), 2)
-        self.assertEqual(graph.nodes[3].children[0], graph.nodes[1])
-        self.assertEqual(graph.nodes[3].children[1], graph.nodes[2])
-        self.assertEqual(graph.nodes[4].text,
-                         'School of Brilliance University of Excellence')
-        self.assertEqual(len(graph.nodes[4].children), 2)
-        self.assertEqual(graph.nodes[4].children[0], graph.nodes[0])
-        self.assertEqual(graph.nodes[4].children[1], graph.nodes[1])
-        self.assertEqual(
-            graph.nodes[5].text,
-            'School of Brilliance University of Excellence and Perseverance')
-        self.assertEqual(len(graph.nodes[5].children), 2)
-        self.assertEqual(graph.nodes[5].children[0], graph.nodes[0])
-        self.assertEqual(graph.nodes[5].children[1], graph.nodes[3])
-        self.assertEqual(graph.nodes[6].text, '21-100 Gallifrey')
-        self.assertEqual(graph.nodes[7].text, 'Perseverance 21-100 Gallifrey')
-        self.assertEqual(len(graph.nodes[7].children), 2)
-        self.assertEqual(graph.nodes[7].children[0], graph.nodes[2])
-        self.assertEqual(graph.nodes[7].children[1], graph.nodes[6])
-        self.assertEqual(
-            graph.nodes[8].text,
-            'University of Excellence and Perseverance 21-100 Gallifrey')
-        self.assertEqual(len(graph.nodes[8].children), 2)
-        self.assertEqual(graph.nodes[8].children[0], graph.nodes[3])
-        self.assertEqual(graph.nodes[8].children[1], graph.nodes[6])
-        self.assertEqual(graph.nodes[9].text, 'Outerspace')
-        self.assertEqual(graph.nodes[10].text, '21-100 Gallifrey Outerspace')
-        self.assertEqual(len(graph.nodes[10].children), 2)
-        self.assertEqual(graph.nodes[10].children[0], graph.nodes[6])
-        self.assertEqual(graph.nodes[10].children[1], graph.nodes[9])
+        self.assertEqual(len(graph.nodes), 5)
+        self.assertEqual(graph.nodes[0].text, 'School of Brilliance University of Excellence and Perseverance 21 100 Gallifrey Outerspace')
+        self.assertEqual(graph.nodes[1].text, 'School of Brilliance')
+        self.assertEqual(graph.nodes[2].text, 'University of Excellence and Perseverance')
+        self.assertEqual(graph.nodes[3].text, '21 100 Gallifrey')
+        self.assertEqual(graph.nodes[4].text, 'Outerspace')
 
     def test_remove_low_scores(self):
         graph = MatchingGraph('University of Excellence, Creativity Institute')
@@ -585,74 +470,6 @@ class TestMatchingGraph(SimpleTestCase):
         self.assertTrue(graph.nodes[1].matched is not None)
         self.assertEqual(graph.nodes[1].matched.substring, 's1')
         self.assertTrue(graph.nodes[2].matched is None)
-
-    def test_prune_links(self):
-        graph = MatchingGraph('School of Brilliance, University of ' +
-                              'Excellence and Perseverance; 21-100 ' +
-                              'Gallifrey: Outerspace')
-        graph.nodes[0].matched = MatchedOrganization(substring='s0',
-                                                     score=10,
-                                                     matching_type='q',
-                                                     organization='obj')
-        graph.nodes[1].matched = MatchedOrganization(substring='s1',
-                                                     score=80,
-                                                     matching_type='q',
-                                                     organization='obj')
-        graph.nodes[2].matched = MatchedOrganization(substring='s2',
-                                                     score=0,
-                                                     matching_type='q',
-                                                     organization='obj')
-        graph.nodes[3].matched = MatchedOrganization(substring='s3',
-                                                     score=100,
-                                                     matching_type='q',
-                                                     organization='obj')
-        graph.nodes[4].matched = MatchedOrganization(substring='s4',
-                                                     score=50,
-                                                     matching_type='q',
-                                                     organization='obj')
-        graph.nodes[5].matched = MatchedOrganization(substring='s5',
-                                                     score=47,
-                                                     matching_type='q',
-                                                     organization='obj')
-        graph.nodes[6].matched = MatchedOrganization(substring='s6',
-                                                     score=5,
-                                                     matching_type='q',
-                                                     organization='obj')
-        graph.nodes[7].matched = MatchedOrganization(substring='s7',
-                                                     score=15,
-                                                     matching_type='q',
-                                                     organization='obj')
-        graph.nodes[8].matched = MatchedOrganization(substring='s8',
-                                                     score=7,
-                                                     matching_type='q',
-                                                     organization='obj')
-        graph.nodes[9].matched = MatchedOrganization(substring='s9',
-                                                     score=60,
-                                                     matching_type='q',
-                                                     organization='obj')
-        graph.nodes[10].matched = MatchedOrganization(substring='sa',
-                                                      score=30,
-                                                      matching_type='q',
-                                                      organization='obj')
-
-        graph.prune_links()
-
-        self.assertTrue(graph.nodes[0].matched is None)
-        self.assertTrue(graph.nodes[1].matched is None)
-        self.assertTrue(graph.nodes[2].matched is None)
-        self.assertTrue(graph.nodes[3].matched is not None)
-        self.assertTrue(graph.nodes[3].matched.substring, 's3')
-        self.assertTrue(graph.nodes[4].matched is not None)
-        self.assertTrue(graph.nodes[4].matched.substring, 's4')
-        self.assertTrue(graph.nodes[5].matched is None)
-        self.assertTrue(graph.nodes[6].matched is None)
-        self.assertTrue(graph.nodes[7].matched is not None)
-        self.assertTrue(graph.nodes[7].matched.substring, 's7')
-        self.assertTrue(graph.nodes[8].matched is None)
-        self.assertTrue(graph.nodes[9].matched is not None)
-        self.assertTrue(graph.nodes[9].matched.substring, 's9')
-        self.assertTrue(graph.nodes[10].matched is None)
-
 
 class TestGenerateOutput(SimpleTestCase):
     def org(self, substring, score, type, id, chosen=False):
@@ -684,11 +501,10 @@ class TestGenerateOutput(SimpleTestCase):
         m12 = self.org('s 4', 0.06, MATCHING_TYPE_PHRASE, 'org5')
         m13 = self.org('s 55', 0.48, MATCHING_TYPE_FUZZY, 'org5')
 
-        c1_ch = self.org('s 1', 1, MATCHING_TYPE_PHRASE, 'org1', chosen=True)
-        c2_ch = self.org('s 2', 0.94, MATCHING_TYPE_FUZZY, 'org2', chosen=True)
+        c1_ch = self.org('s 1', 1, MATCHING_TYPE_PHRASE, 'org1', chosen=False)
 
         self.assertEquals(
             get_output(
                 [c1, c2],
                 [m1, m2, m3, m4, m5, m6, m7, m8, m9, m10, m11, m12, m13]),
-            [c1_ch, c2_ch, m10, m7, m11])
+            [c1_ch, m4, m10, m7])

--- a/rorapi/tests/tests_matching.py
+++ b/rorapi/tests/tests_matching.py
@@ -359,15 +359,6 @@ class TestMatchingNode(SimpleTestCase):
         self.assertEqual(empty.text, 'text')
         self.assertTrue(empty.matched is None)
 
-    def test_get_matching_types(self):
-        empty = MatchingNode('text')
-        self.assertEqual(len(empty.get_matching_types()), 4)
-
-    def test_get_matching_types(self):
-        empty = MatchingNode('text')
-        self.assertEqual(len(empty.get_matching_types()), 4)
-
-
 class TestCleanSearchString(SimpleTestCase):
     def test_init(self):
         self.assertEqual(clean_search_string('university of excellence'),


### PR DESCRIPTION
- Check for exact matches first
- De-prioritize acronym search results
- Don't mark multiple results as chosen = True
- Exclude search strings that match specific common phrases, country names, country codes and city names 
- String special chars (except &) from search strings
- Include full entered string as a search term in all searches
- Generate fewer search substrings
- Only return results with a score of >= .5