### PR TITLE
Client ID Registration: QA feedback

### DIFF
--- a/rorapi/common/views.py
+++ b/rorapi/common/views.py
@@ -81,7 +81,7 @@ class ClientRegistrationView(APIView):
 
             Requests without a valid client ID are subject to a rate limit of 50 requests per 5 minute period.
 
-            We do not provide a way to recover or revoke a lost client ID. If you lose track of your client ID, please register a new client ID. For more information about ROR API client IDs, see https://ror.readme.io
+            We do not provide a way to recover or revoke a lost client ID. If you lose track of your client ID, please register a new client ID. For more information about ROR API client IDs, see https://ror.readme.io/docs/client-id
 
             If you have questions, please see ROR documentation or contact us at support@ror.org
 
@@ -103,7 +103,7 @@ class ClientRegistrationView(APIView):
                 <pre style="background:#f4f4f4;padding:10px;">curl -H "Client-Id: {client_id}" https://api.ror.org/organizations?query=oxford</pre>
                 <p>Requests without a valid client ID are subject to a rate limit of 50 requests per 5 minute period.</p>
                 <p>We do not provide a way to recover or revoke a lost client ID. If you lose track of your client ID, please register a new one.</p>
-                <p>For more information about ROR API client IDs, see <a href="https://ror.readme.io/">our documentation</a>.</p>
+                <p>For more information about ROR API client IDs, see <a href="https://ror.readme.io/docs/client-id/">our documentation</a>.</p>
                 <p>If you have questions, please see the ROR documentation or contact us at <a href="mailto:support@ror.org">support@ror.org</a>.</p>
                 <p>Cheers,<br>
                 The ROR Team<br>

--- a/rorapi/common/views.py
+++ b/rorapi/common/views.py
@@ -52,7 +52,7 @@ class ClientRegistrationView(APIView):
             client = serializer.save()
 
             subject = 'ROR API client ID'
-            from_email = 'support@ror.org'
+            from_email = 'api@ror.org'
             recipient_list = [client.email]
 
             html_content = self._get_html_content(client.client_id)
@@ -83,11 +83,11 @@ class ClientRegistrationView(APIView):
 
             We do not provide a way to recover or revoke a lost client ID. If you lose track of your client ID, please register a new client ID. For more information about ROR API client IDs, see https://ror.readme.io/docs/client-id
 
-            If you have questions, please see ROR documentation or contact us at support@ror.org
+            If you have questions, please see ROR documentation or contact us at api@ror.org
 
             Cheers,
             The ROR Team
-            support@ror.org
+            api@ror.org
             https://ror.org
         """
 
@@ -104,10 +104,10 @@ class ClientRegistrationView(APIView):
                 <p>Requests without a valid client ID are subject to a rate limit of 50 requests per 5 minute period.</p>
                 <p>We do not provide a way to recover or revoke a lost client ID. If you lose track of your client ID, please register a new one.</p>
                 <p>For more information about ROR API client IDs, see <a href="https://ror.readme.io/docs/client-id/">our documentation</a>.</p>
-                <p>If you have questions, please see the ROR documentation or contact us at <a href="mailto:support@ror.org">support@ror.org</a>.</p>
+                <p>If you have questions, please see the ROR documentation or contact us at <a href="mailto:api@ror.org">api@ror.org</a>.</p>
                 <p>Cheers,<br>
                 The ROR Team<br>
-                <a href="mailto:support@ror.org">support@ror.org</a><br>
+                <a href="mailto:api@ror.org">api@ror.org</a><br>
                 <a href="https://ror.org">https://ror.org</a></p>
             </div>
         """


### PR DESCRIPTION
- On the form, the line "For more information about ROR API client IDs, see [https://ror.readme.io/XXXXX](https://www.google.com/url?q=https://ror.readme.io/XXXXX&sa=D&source=docs&ust=1746433086505021&usg=AOvVaw3PyZtU_dE2Boue8S75j0Mp)" can point to [https://ror.readme.io/docs/client-id](https://www.google.com/url?q=https://ror.readme.io/docs/client-id&sa=D&source=docs&ust=1746433086505187&usg=AOvVaw0mEjZIqw8EvCITA5CPOsvC)