### PR TITLE
Add configurable default and parameter-based strategy selection for affiliation matching

### DIFF
--- a/rorapi/common/views.py
+++ b/rorapi/common/views.py
@@ -14,6 +14,7 @@ import magic
 from rorapi.common.create_update import new_record_from_json, update_record_from_json
 from rorapi.common.csv_bulk import process_csv
 from rorapi.common.csv_utils import validate_csv
+from django.conf import settings
 from rorapi.settings import REST_FRAMEWORK, ES7, ES_VARS
 from rorapi.common.matching import match_organizations
 from rorapi.common.matching_single_search import match_organizations as single_search_match_organizations
@@ -152,6 +153,10 @@ class OrganizationViewSet(viewsets.ViewSet):
             del params["format"]
         if "affiliation" in params:
             if "single_search" in params:
+                errors, organizations = single_search_match_organizations(params)
+            elif "multisearch" in params:
+                errors, organizations = match_organizations(params)
+            elif settings.SINGLE_SEARCH_DEFAULT:
                 errors, organizations = single_search_match_organizations(params)
             else:
                 errors, organizations = match_organizations(params)

--- a/rorapi/settings.py
+++ b/rorapi/settings.py
@@ -299,6 +299,10 @@ LAUNCH_DARKLY_KEY = os.environ.get('LAUNCH_DARKLY_KEY')
 # Toggle for behavior-based rate limiting
 ENABLE_BEHAVIORAL_LIMITING = os.getenv("ENABLE_BEHAVIORAL_LIMITING", "False") == "True"
 
+# When True, affiliation matching defaults to single search; otherwise multisearch.
+# Request params single_search and multisearch override this.
+SINGLE_SEARCH_DEFAULT = os.getenv("SINGLE_SEARCH_DEFAULT", "False") == "True"
+
 # Email settings for Django
 EMAIL_BACKEND = 'django_ses.SESBackend'
 AWS_ACCESS_KEY_ID = os.environ.get('AWS_ACCESS_KEY_ID')


### PR DESCRIPTION
## Purpose

The purpose of this PR is to introduce a configurable default for the affiliation matching logic in the ROR API and allow users to explicitly choose between the `single_search` and `multisearch` matching methods via request parameters.

## Approach

The logic in `OrganizationViewSet` has been updated to evaluate matching strategy based on a hierarchy:
1. Explicit request parameters (`single_search` or `multisearch`).
2. A global environment variable configuration (`SINGLE_SEARCH_DEFAULT`).
3. Fallback to the legacy multisearch behavior.

### Key Modifications

- **rorapi/settings.py**: Added `SINGLE_SEARCH_DEFAULT` setting, controlled by an environment variable (defaults to `False`).
- **rorapi/common/views.py**: Updated the `list` method in `OrganizationViewSet` to check for matching parameters and the new configuration setting.
- **rorapi/tests/tests_unit/tests_views_v2.py**: Added a new test suite `AffiliationDefaultMatchingTestCase` to verify that the logic correctly identifies which matching function to call based on different settings and query parameters.

### Important Technical Details

- The `multisearch` parameter now acts as an explicit override to force the legacy matching logic even if `SINGLE_SEARCH_DEFAULT` is enabled.
- The default behavior remains unchanged unless the environment variable `SINGLE_SEARCH_DEFAULT` is explicitly set to `True`.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.