### PR TITLE
[STAGING] Add configurable default and parameter-based strategy selection for a…

### DIFF
--- a/rorapi/common/views.py
+++ b/rorapi/common/views.py
@@ -14,6 +14,7 @@ import magic
 from rorapi.common.create_update import new_record_from_json, update_record_from_json
 from rorapi.common.csv_bulk import process_csv
 from rorapi.common.csv_utils import validate_csv
+from django.conf import settings
 from rorapi.settings import REST_FRAMEWORK, ES7, ES_VARS
 from rorapi.common.matching import match_organizations
 from rorapi.common.matching_single_search import match_organizations as single_search_match_organizations
@@ -152,6 +153,10 @@ class OrganizationViewSet(viewsets.ViewSet):
             del params["format"]
         if "affiliation" in params:
             if "single_search" in params:
+                errors, organizations = single_search_match_organizations(params)
+            elif "multisearch" in params:
+                errors, organizations = match_organizations(params)
+            elif settings.SINGLE_SEARCH_DEFAULT:
                 errors, organizations = single_search_match_organizations(params)
             else:
                 errors, organizations = match_organizations(params)

--- a/rorapi/settings.py
+++ b/rorapi/settings.py
@@ -299,6 +299,10 @@ LAUNCH_DARKLY_KEY = os.environ.get('LAUNCH_DARKLY_KEY')
 # Toggle for behavior-based rate limiting
 ENABLE_BEHAVIORAL_LIMITING = os.getenv("ENABLE_BEHAVIORAL_LIMITING", "False") == "True"
 
+# When True, affiliation matching defaults to single search; otherwise multisearch.
+# Request params single_search and multisearch override this.
+SINGLE_SEARCH_DEFAULT = os.getenv("SINGLE_SEARCH_DEFAULT", "False") == "True"
+
 # Email settings for Django
 EMAIL_BACKEND = 'django_ses.SESBackend'
 AWS_ACCESS_KEY_ID = os.environ.get('AWS_ACCESS_KEY_ID')


### PR DESCRIPTION
…ffiliation matching (#526)

* feat: add SINGLE_SEARCH_DEFAULT setting for affiliation matching

* feat: add multisearch support and single search default to affiliation matching

* test: add unit tests for affiliation single search and multisearch logic