### PR TITLE
Refactor: Change IndexData and IndexDataDump to POST

### DIFF
--- a/rorapi/common/views.py
+++ b/rorapi/common/views.py
@@ -266,7 +266,7 @@ class GenerateId(APIView):
 class IndexData(APIView):
     permission_classes = [OurTokenPermission]
 
-    def get(self, request, branch, version=REST_FRAMEWORK["DEFAULT_VERSION"]):
+    def post(self, request, branch, version=REST_FRAMEWORK["DEFAULT_VERSION"]):
         st = 200
         msg = process_files(branch, 'v2')
         if msg["status"] == "ERROR":
@@ -276,7 +276,7 @@ class IndexData(APIView):
 class IndexDataDump(APIView):
     permission_classes = [OurTokenPermission]
 
-    def get(self, request, filename, dataenv, version=REST_FRAMEWORK["DEFAULT_VERSION"]):
+    def post(self, request, filename, dataenv, version=REST_FRAMEWORK["DEFAULT_VERSION"]):
         # Always use v2 schema - v1 indexing support has been removed
         schema = 2
         testdata = True

--- a/rorapi/tests/tests_unit/tests_views_v2.py
+++ b/rorapi/tests/tests_unit/tests_views_v2.py
@@ -354,7 +354,7 @@ class IndexRorViewTestCase(SimpleTestCase):
     def test_index_ror_success(self, index_mock, permission_mock):
         index_mock.return_value = self.success_msg
         permission_mock.return_value = True
-        response = self.client.get('/v2/indexdata/foo')
+        response = self.client.post('/v2/indexdata/foo')
         self.assertEquals(response.status_code, 200)
 
     @mock.patch('rorapi.common.views.OurTokenPermission.has_permission')
@@ -362,14 +362,32 @@ class IndexRorViewTestCase(SimpleTestCase):
     def test_index_ror_fail_error(self, index_mock, permission_mock):
         index_mock.return_value = self.error_msg
         permission_mock.return_value = True
-        response = self.client.get('/v2/indexdata/foo')
+        response = self.client.post('/v2/indexdata/foo')
         self.assertEquals(response.status_code, 400)
 
     @mock.patch('rorapi.common.views.OurTokenPermission.has_permission')
     def test_index_ror_fail_no_permission(self, permission_mock):
         permission_mock.return_value = False
-        response = self.client.get('/v2/indexdata/foo')
+        response = self.client.post('/v2/indexdata/foo')
         self.assertEquals(response.status_code, 403)
+
+    @mock.patch.dict(os.environ, {"TOKEN": "token-value", "ROUTE_USER": "route-user"}, clear=False)
+    @mock.patch('rorapi.common.views.process_files')
+    def test_index_ror_fail_no_auth_headers(self, index_mock):
+        index_mock.return_value = self.success_msg
+        response = self.client.post('/v2/indexdata/foo')
+        self.assertEquals(response.status_code, 403)
+
+    @mock.patch.dict(os.environ, {"TOKEN": "token-value", "ROUTE_USER": "route-user"}, clear=False)
+    @mock.patch('rorapi.common.views.process_files')
+    def test_index_ror_success_with_auth_headers(self, index_mock):
+        index_mock.return_value = self.success_msg
+        response = self.client.post(
+            '/v2/indexdata/foo',
+            HTTP_TOKEN='token-value',
+            HTTP_ROUTE_USER='route-user'
+        )
+        self.assertEquals(response.status_code, 200)
 
 class HeartbeatViewTestCase(SimpleTestCase):
     def setUp(self):
@@ -446,7 +464,7 @@ class IndexRorDumpViewTestCase(SimpleTestCase):
     def test_index_ror_success(self, index_mock, permission_mock):
         index_mock.return_value = self.success_msg
         permission_mock.return_value = True
-        response = self.client.get('/v2/indexdatadump/v1.1-1111-11-11-ror-data/prod')
+        response = self.client.post('/v2/indexdatadump/v1.1-1111-11-11-ror-data/prod')
         self.assertEquals(response.status_code, 200)
 
     @mock.patch('rorapi.common.views.OurTokenPermission.has_permission')
@@ -454,11 +472,29 @@ class IndexRorDumpViewTestCase(SimpleTestCase):
     def test_index_ror_fail_error(self, index_mock, permission_mock):
         index_mock.return_value = self.error_msg
         permission_mock.return_value = True
-        response = self.client.get('/v2/indexdatadump/v1.1-1111-11-11-ror-data/prod')
+        response = self.client.post('/v2/indexdatadump/v1.1-1111-11-11-ror-data/prod')
         self.assertEquals(response.status_code, 400)
 
     @mock.patch('rorapi.common.views.OurTokenPermission.has_permission')
     def test_index_ror_fail_no_permission(self, permission_mock):
         permission_mock.return_value = False
-        response = self.client.get('/v2/indexdatadump/v1.1-1111-11-11-ror-data/prod')
+        response = self.client.post('/v2/indexdatadump/v1.1-1111-11-11-ror-data/prod')
         self.assertEquals(response.status_code, 403)
+
+    @mock.patch.dict(os.environ, {"TOKEN": "token-value", "ROUTE_USER": "route-user"}, clear=False)
+    @mock.patch('django.core.management.call_command')
+    def test_index_ror_dump_fail_no_auth_headers(self, index_mock):
+        index_mock.return_value = self.success_msg
+        response = self.client.post('/v2/indexdatadump/v1.1-1111-11-11-ror-data/prod')
+        self.assertEquals(response.status_code, 403)
+
+    @mock.patch.dict(os.environ, {"TOKEN": "token-value", "ROUTE_USER": "route-user"}, clear=False)
+    @mock.patch('django.core.management.call_command')
+    def test_index_ror_dump_success_with_auth_headers(self, index_mock):
+        index_mock.return_value = self.success_msg
+        response = self.client.post(
+            '/v2/indexdatadump/v1.1-1111-11-11-ror-data/prod',
+            HTTP_TOKEN='token-value',
+            HTTP_ROUTE_USER='route-user'
+        )
+        self.assertEquals(response.status_code, 200)


### PR DESCRIPTION
## Purpose

This PR changes the HTTP method for the `IndexData` and `IndexDataDump` views from `GET` to `POST`. This change is made to align with the best practices for endpoints that perform write operations or trigger significant actions.

## Approach

The `GET` method is generally used for retrieving data, while `POST` is more appropriate for operations that may alter server state or submit data. By changing these endpoints to `POST`, we ensure that their usage is consistent with their intended functionality.

### Key Modifications

*   Changed the HTTP method for `IndexData` view from `GET` to `POST`.
*   Changed the HTTP method for `IndexDataDump` view from `GET` to `POST`.
*   Updated unit tests to reflect the change in HTTP methods for both views.
*   Added new tests for `IndexData` and `IndexDataDump` to verify authentication header handling when using `POST`.

### Important Technical Details

*   The change to `POST` for `IndexData` and `IndexDataDump` improves the semantic correctness of the API.
*   The added tests ensure that the authentication mechanism correctly handles incoming `POST` requests with `TOKEN` and `ROUTE_USER` headers.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.